### PR TITLE
Implementation of problem via React components

### DIFF
--- a/react-opaque-components-bodhi/README.md
+++ b/react-opaque-components-bodhi/README.md
@@ -1,0 +1,36 @@
+# Scalable frontend, with React/Redux/Whatever-react-based-library-you-want
+
+This feels a little bit like cheating, but given the problem definition, especially the emphasis on decoupling, I thought that perhaps there's no need to force each component to be implemented with Redux, Redux + redux-thunk, Redux + Sagas, Mobx, whatever.
+
+Instead, each component is rendered as an "opaque" React component. They are opaque in that the integration team has no idea *how* each other team has implemented their component (or even really care), they just have to implement a defined business-level interface (exposed as a React component).
+
+One drawback of this approach is that you no longer have a single state atom, but if you're really serious about decoupling, this is a plus, right? ;) Any state sharing between components needs to become explicit, but not so convenient...
+
+One interesting thing about this approach (that may also be true of the other approaches, I haven't studied them closely) is that it could easily support having *N counters* and *N buttons*. The integration team could wire them up however they like.
+
+# Interfaces
+
+1. A `NewGif` type component must take an `onNewGif` prop, that is a function of type `() => void`.
+
+2. A `Button` component must have a function `buttonState`, of type `() => bool`, that returns the button's state ("active" => `true`).
+
+3. A `Counter` component must have a function `increment` of type `bool => void`, that will increment the counter. The interface does not specify whether the `Counter` implements the business rule, as this is an internal detail that should be hidden from the user of the component.
+
+# Implementation
+
+`NewGif` is implemented as a Redux app that will, when the button is pressed:
+
+1. Fetch gif metadata from the Giphy API.
+2. Dispatch `NEW_GIF` into its own store (which will cause the `connect`ed `Gif` component to update with the new gif URL.
+3. Call the function passed as `onNewGif` to signal that the gif was changed.
+
+`GifPair` and `PairPair` are basically dumb components that pass their `onNewGif` props straight through to the child `NewGif`.
+
+`Button` is a plain React component that stores its button's state in the React component state. It exposes the button state via a function on the class `buttonState`.
+
+`Counter` is also implemented as a Redux app that has a single Redux action: `INC`, that has `buttonState` as the payload. The ability to trigger a dispatch of this action is exposed to users of the component via the `increment` function on the component. The business rule is implemented in the reducer, with `counter` coming from the state, and `buttonState` coming from the action.
+
+`App` wires the components together by:
+
+1. Keeping a ref to the counter and the button.
+2. Providing a function as the `onNewGif` prop of any Gif-like component (`NewGif`, `GifPair`, `PairPair`) that gets the button state via the ref, and trigges the counter increment (again via a ref), passing along the button state.

--- a/react-opaque-components-bodhi/index.html
+++ b/react-opaque-components-bodhi/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Sample App</title>
+  </head>
+  <body>
+    <div id='root'>
+    </div>
+    <script src="/static/bundle.js"></script>
+  </body>
+</html>

--- a/react-opaque-components-bodhi/package.json
+++ b/react-opaque-components-bodhi/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "react-hot-boilerplate",
+  "version": "1.0.0",
+  "description": "Boilerplate for ReactJS project with hot code reloading",
+  "scripts": {
+    "start": "node server.js",
+    "lint": "eslint src"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gaearon/react-hot-boilerplate.git"
+  },
+  "keywords": [
+    "react",
+    "reactjs",
+    "boilerplate",
+    "hot",
+    "reload",
+    "hmr",
+    "live",
+    "edit",
+    "webpack"
+  ],
+  "author": "Dan Abramov <dan.abramov@me.com> (http://github.com/gaearon)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gaearon/react-hot-boilerplate/issues"
+  },
+  "homepage": "https://github.com/gaearon/react-hot-boilerplate",
+  "devDependencies": {
+    "babel-core": "^6.0.20",
+    "babel-eslint": "^4.1.3",
+    "babel-loader": "^6.0.1",
+    "babel-preset-es2015": "^6.0.15",
+    "babel-preset-react": "^6.0.15",
+    "babel-preset-stage-0": "^6.0.15",
+    "eslint": "^1.10.3",
+    "eslint-plugin-react": "^3.6.2",
+    "react-hot-loader": "^1.3.0",
+    "webpack": "^1.12.2",
+    "webpack-dev-server": "^1.12.1"
+  },
+  "dependencies": {
+    "exports-loader": "^0.6.3",
+    "imports-loader": "^0.6.5",
+    "react": "^0.14.6",
+    "react-dom": "^0.14.6",
+    "react-redux": "^4.4.5",
+    "redux": "^3.5.2",
+    "whatwg-fetch": "^1.0.0"
+  }
+}

--- a/react-opaque-components-bodhi/server.js
+++ b/react-opaque-components-bodhi/server.js
@@ -1,0 +1,15 @@
+var webpack = require('webpack');
+var WebpackDevServer = require('webpack-dev-server');
+var config = require('./webpack.config');
+
+new WebpackDevServer(webpack(config), {
+  publicPath: config.output.publicPath,
+  hot: true,
+  historyApiFallback: true
+}).listen(3000, 'localhost', function (err, result) {
+  if (err) {
+    return console.log(err);
+  }
+
+  console.log('Listening at http://localhost:3000/');
+});

--- a/react-opaque-components-bodhi/src/App.js
+++ b/react-opaque-components-bodhi/src/App.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import { NewGif, GifPair, PairPair } from './Gif';
+import { App as Button } from './Button';
+import { App as Counter } from './Counter';
+
+export default class App extends Component {
+    constructor(props) {
+        super(props);
+        this.onNewGif = this.onNewGif.bind(this);
+    }
+    onNewGif() {
+        const state = this.refs.button.buttonState();
+        this.refs.counter.increment(state);
+    }
+    render() {
+        return (
+            <div>
+                <NewGif onNewGif={this.onNewGif}/>
+                <GifPair onNewGif={this.onNewGif}/>
+                <PairPair onNewGif={this.onNewGif}/>
+                <Button ref="button" />
+                <Counter ref="counter" />
+            </div>
+        );
+    }
+}

--- a/react-opaque-components-bodhi/src/Button.js
+++ b/react-opaque-components-bodhi/src/Button.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+
+class App extends Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            toggled: false
+        }
+        this._toggle = this._toggle.bind(this);
+    }
+    _toggle() {
+        this.setState({ toggled: !this.state.toggled })
+    }
+    render() {
+        const toggled = this.state.toggled;
+        return <button onClick={this._toggle}>
+            {toggled ? "green" : "red"}
+        </button>;
+    }
+    buttonState() {
+        return this.state.toggled;
+    }
+}
+
+export {
+    App
+}

--- a/react-opaque-components-bodhi/src/Counter.js
+++ b/react-opaque-components-bodhi/src/Counter.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+import { createStore } from 'redux';
+import { Provider, connect } from 'react-redux';
+
+const INC = 'INC';
+
+const reducer = (s = 0, a) => {
+    if (a.type === INC) {
+        if (s >= 10 && a.buttonState) {
+            return s + 2;
+        } else {
+            return s + 1;
+        }
+    }
+    return s;
+};
+
+const increment = (buttonState) => ({
+    type: INC,
+    buttonState
+});
+
+const store = createStore(reducer);
+
+const Counter = connect(
+    (counter) => ({ counter })
+)(({ counter }) =>
+    <h1>Counter {counter}</h1>
+);
+
+class App extends Component {
+    render() {
+        return <Provider store={store}>
+            <Counter />
+        </Provider>
+    }
+    increment(buttonState) {
+        store.dispatch(increment(buttonState));
+    }
+}
+
+export {
+    App
+}

--- a/react-opaque-components-bodhi/src/Gif.js
+++ b/react-opaque-components-bodhi/src/Gif.js
@@ -1,0 +1,75 @@
+import React, { Component } from 'react';
+import { createStore } from 'redux';
+import { Provider, connect } from 'react-redux';
+
+const NEW_GIF = 'NEW_GIF'
+
+const waiting = 'https://raw.githubusercontent.com/jarvisaoieong/redux-architecture/master/src/modules/randomGif/components/waiting.gif';
+
+const getGif = () => fetch('//api.giphy.com/v1/gifs/random?api_key=dc6zaTOxFJmzC&tag=kittens')
+    .then(req => req.json())
+    .then(data => data.data.image_url);
+
+const reducer = (s = waiting, a) => {
+    switch (a.type) {
+    case NEW_GIF:
+        return a.gif
+    }
+    return s
+}
+
+const Gif = connect(
+    gif => ({ gif })
+)(
+    ({ gif }) => <img src={gif} />
+)
+
+class NewGif extends Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            onNewGif: props.onNewGif,
+            store: createStore(reducer)
+        }
+        this.newGif = this.newGif.bind(this);
+    }
+    newGif() {
+        getGif().then(url => {
+            this.state.store.dispatch({ type: NEW_GIF, gif: url });
+            if (this.state.onNewGif()) {
+                this.state.onNewGif();
+            };
+        }).catch(err => console.error(err));
+    }
+    render() {
+        const gif = this.state.store.getState();
+        return (
+            <Provider store={this.state.store}>
+                <div>
+                    <button onClick={this.newGif}>MOAR</button>
+                    <Gif />
+                </div>
+            </Provider>
+        );
+    }
+}
+
+const GifPair = ({ onNewGif }) =>
+    <div style={{border: '1px solid #CCC'}}>
+        <h2>Gif Pair</h2>
+        <NewGifApp onNewGif={onNewGif} />
+        <NewGifApp onNewGif={onNewGif} />
+    </div>;
+
+const PairPair = ({ onNewGif }) =>
+    <div style={{border: '1px solid #CCC'}}>
+        <h2>Gif Pair Pair</h2>
+        <GifPair onNewGif={onNewGif} />
+        <GifPair onNewGif={onNewGif} />
+    </div>;
+
+export {
+    NewGif,
+    GifPair,
+    PairPair
+}

--- a/react-opaque-components-bodhi/src/index.js
+++ b/react-opaque-components-bodhi/src/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/react-opaque-components-bodhi/webpack.config.js
+++ b/react-opaque-components-bodhi/webpack.config.js
@@ -1,0 +1,29 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  devtool: 'eval',
+  entry: [
+    'webpack-dev-server/client?http://localhost:3000',
+    'webpack/hot/only-dev-server',
+    './src/index'
+  ],
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/static/'
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+      new webpack.ProvidePlugin({
+          'fetch': 'imports?this=>global!exports?global.fetch!whatwg-fetch'
+      })
+  ],
+  module: {
+    loaders: [{
+      test: /\.js$/,
+      loaders: ['react-hot', 'babel'],
+      include: path.join(__dirname, 'src')
+    }]
+  }
+};


### PR DESCRIPTION
(copied from `README.md`)
# Scalable frontend, with React/Redux/Whatever-react-based-library-you-want

This feels a little bit like cheating, but given the problem definition, especially the emphasis on decoupling, I thought that perhaps there's no need to force each component to be implemented with Redux, Redux + redux-thunk, Redux + Sagas, Mobx, whatever.

Instead, each component is rendered as an "opaque" React component. They are opaque in that the integration team has no idea _how_ each other team has implemented their component (or even really care), they just have to implement a defined business-level interface (exposed as a React component).

One drawback of this approach is that you no longer have a single state atom, but if you're really serious about decoupling, this is a plus, right? ;) Any state sharing between components needs to become explicit, but not so convenient...

One interesting thing about this approach (that may also be true of the other approaches, I haven't studied them closely) is that it could easily support having _N counters_ and _N buttons_. The integration team could wire them up however they like.
# Interfaces
1. A `NewGif` type component must take an `onNewGif` prop, that is a function of type `() => void`.
2. A `Button` component must have a function `buttonState`, of type `() => bool`, that returns the button's state ("active" => `true`).
3. A `Counter` component must have a function `increment` of type `bool => void`, that will increment the counter. The interface does not specify whether the `Counter` implements the business rule, as this is an internal detail that should be hidden from the user of the component.
# Implementation

`NewGif` is implemented as a Redux app that will, when the button is pressed:
1. Fetch gif metadata from the Giphy API.
2. Dispatch `NEW_GIF` into its own store (which will cause the `connect`ed `Gif` component to update with the new gif URL.
3. Call the function passed as `onNewGif` to signal that the gif was changed.

`GifPair` and `PairPair` are basically dumb components that pass their `onNewGif` props straight through to the child `NewGif`.

`Button` is a plain React component that stores its button's state in the React component state. It exposes the button state via a function on the class `buttonState`.

`Counter` is also implemented as a Redux app that has a single Redux action: `INC`, that has `buttonState` as the payload. The ability to trigger a dispatch of this action is exposed to users of the component via the `increment` function on the component. The business rule is implemented in the reducer, with `counter` coming from the state, and `buttonState` coming from the action.

`App` wires the components together by:
1. Keeping a ref to the counter and the button.
2. Providing a function as the `onNewGif` prop of any Gif-like component (`NewGif`, `GifPair`, `PairPair`) that gets the button state via the ref, and trigges the counter increment (again via a ref), passing along the button state.
